### PR TITLE
✨: H2への初期データ投入や起動モードを、テスト時とそうではない場合とで分けました

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,9 +275,6 @@
             <ports>
               <port>8080</port>
             </ports>
-            <environment>
-              <FLYWAY_CLEANBEFOREMIGRATE>false</FLYWAY_CLEANBEFOREMIGRATE>
-            </environment>
           </container>
         </configuration>
       </plugin>

--- a/src/test/resources/env.config
+++ b/src/test/resources/env.config
@@ -2,7 +2,7 @@
 nablarch.db.jdbcDriver=org.h2.Driver
 
 # JDBC接続URL(DataSourceを直接使用する際の項目)
-nablarch.db.url=jdbc:h2:./h2/db/nablarch_example;AUTO_SERVER=TRUE;MODE=PostgreSQL
+nablarch.db.url=jdbc:h2:mem:nablarch_example;MODE=PostgreSQL
 
 # DB接続ユーザ名(DataSourceを直接使用する際の項目)
 nablarch.db.user=example
@@ -36,8 +36,8 @@ nablarch.db.validationTimeout=5000
 nablarch.codeCache.loadOnStartUp=false
 
 # Flywayの設定
-flyway.locations=db/migration
-flyway.cleanBeforeMigrate=false
+flyway.locations=db/migration,filesystem:src/test/resources/db/testdata
+flyway.cleanBeforeMigrate=true
 
 # CORSで許可するオリジン
 cors.origins=http://localhost:3000


### PR DESCRIPTION
## ✅ What's done

- [x] `./mvnw jetty:run`、もしくはDockerから起動した場合は、アプリ起動時にH2のデータをクリーンニングしないように変更
- [x] `./mvnw jetty:run`でアプリ起動した場合、ToDoデータは初期データとして登録しないようにしました（Docker起動時の動作に合わせました）
- [x] テスト時は、H2をインメモリで動作させるようにしました

---

## Tests

- [x] `./mvnw test`
- [x] `./mvnw jetty:run`でアプリ起動後、curlでAPI実行
- [x] Dockerでアプリ起動後、curlでAPI実行

## Other (messages to reviewers, concerns, etc.)

Nablarchの解説書によると、環境設定値を環境ごとに切り替えるためにはプロファイルを定義する方法が説明されていますが、
今回はシンプルにmainリソースに配置している`env.config`と同名のファイルをtestリソースにもおいて、テスト時はそちらを参照するにしてます。

[Nablarch 9.2.5. 環境ごとに環境設定値を切り替える方法](https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/setting_guide/ManagingEnvironmentalConfiguration/index.html#how-to-switch-env-values)
