### PR TITLE
✨: H2への初期データ投入や起動モードをテスト時だけOverrideする設定を入れる

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,9 +275,6 @@
             <ports>
               <port>8080</port>
             </ports>
-            <environment>
-              <FLYWAY_CLEANBEFOREMIGRATE>false</FLYWAY_CLEANBEFOREMIGRATE>
-            </environment>
           </container>
         </configuration>
       </plugin>

--- a/src/main/resources/env.config
+++ b/src/main/resources/env.config
@@ -36,8 +36,8 @@ nablarch.db.validationTimeout=5000
 nablarch.codeCache.loadOnStartUp=false
 
 # Flywayの設定
-flyway.locations=db/migration,filesystem:src/test/resources/db/testdata
-flyway.cleanBeforeMigrate=true
+flyway.locations=db/migration
+flyway.cleanBeforeMigrate=false
 
 # CORSで許可するオリジン
 cors.origins=http://localhost:3000

--- a/src/test/resources/override/env.config
+++ b/src/test/resources/override/env.config
@@ -1,0 +1,6 @@
+# JDBC接続URL(DataSourceを直接使用する際の項目)
+nablarch.db.url=jdbc:h2:mem:nablarch_example;MODE=PostgreSQL
+
+# Flywayの設定
+flyway.locations=db/migration,filesystem:src/test/resources/db/testdata
+flyway.cleanBeforeMigrate=true

--- a/src/test/resources/unit-test.xml
+++ b/src/test/resources/unit-test.xml
@@ -6,6 +6,7 @@
 
   <import file="rest-component-configuration.xml" />
 
+  <config-file file="override/env.config" />
   <!-- テスティングフレームワークの設定 -->
   <import file="nablarch/test/rest-request-test.xml"/>
 


### PR DESCRIPTION
## ✅ What's done

- [x] `test/resources/override/env.config` に差分のキーを定義して単体テスト用のコンポーネント定義ファイルから読み込む

<!-- 該当するものがなければ、このセクション（この行から「## Devices」の前の行まで）を削除してください。 -->
## Tests

- [x] `mvn jetty:run` でデータを投入し、`mvn test` 後にデータが残るか確認

## Other (messages to reviewers, concerns, etc.)

なし